### PR TITLE
perf: drop references that outlive size calculation

### DIFF
--- a/src/main/java/osmosis/folder/inspector/container/state/ChildrenContainersWrapper.java
+++ b/src/main/java/osmosis/folder/inspector/container/state/ChildrenContainersWrapper.java
@@ -9,11 +9,10 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 public class ChildrenContainersWrapper {
-    private final File file;
-    private final DirectoryContainer directoryContainer;
+    private File file;
+    private DirectoryContainer directoryContainer;
     private State state = new EmptyState();
     private List<Container> containers;
 
@@ -39,16 +38,18 @@ public class ChildrenContainersWrapper {
         public List<Container> getChildrenContainers() {
             containers = Arrays.stream(Optional.ofNullable(file.listFiles()).orElse(Constant.EMPTY_FILES_ARRAY))
                     .map(child -> ContainerFactory.createContainer(child, directoryContainer))
-                    .collect(Collectors.toList());
+                    .toList();
+            file = null;
+            directoryContainer = null;
             state = new InitializedState();
-            return state.getChildrenContainers();
+            return containers;
         }
     }
 
     private class InitializedState implements State {
         @Override
         public List<Container> getChildrenContainers() {
-            return List.copyOf(containers);
+            return containers;
         }
     }
 }

--- a/src/main/java/osmosis/folder/inspector/controllers/FoldersController.java
+++ b/src/main/java/osmosis/folder/inspector/controllers/FoldersController.java
@@ -106,6 +106,7 @@ public class FoldersController extends Controller implements ChildContainerReady
     }
 
     private void goBackToMainMenu(ActionEvent actionEvent) {
+        containerManager.getCurrentContainer().clearChildContainerReadyListener();
         setScene(actionEvent, ResourcePaths.MAIN_FXML);
         ContainerManager.getInstance().clearContainer();
     }


### PR DESCRIPTION
Closes #2

## Summary
- `ChildrenContainersWrapper.file` and `ChildrenContainersWrapper.directoryContainer` are nulled after `EmptyState` populates the children list, since they are only consumed during the one-shot `listFiles()` + `ContainerFactory.createContainer(...)` pass. The `directoryContainer` field was a back-reference into the wrapper's owning `DirectoryContainer`, doubling per-directory retained overhead for the entire scanned tree.
- `InitializedState.getChildrenContainers()` now returns the cached immutable list directly instead of re-allocating a defensive `List.copyOf(...)` on every call. The list is built once via `Stream.toList()` (already immutable), so each subsequent call to `getChildrenContainers()` no longer churns a new array.
- `FoldersController.goBackToMainMenu` now clears the `ChildContainerReadyListener` on the current container before tearing down the scene. Previously, in-flight `DirectorySizeCalculationTask`s could keep walking up to the root and invoking the listener (and thus pinning the orphaned controller) until the entire background calculation finished, even though the user had left the folders view.

## Test plan
- [x] `mvn clean verify` (checkstyle + 6 tests) passes
- [ ] Manual: open a large directory, navigate back to the main menu while calculation is still running, confirm app remains responsive
- [ ] Manual: navigate into and out of subdirectories, confirm sizes still display correctly

Generated with [Claude Code](https://claude.com/claude-code)