### PR TITLE
feat: add application logging via java.util.logging

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 module osmosis.folderinspector {
+    requires java.logging;
     requires javafx.controls;
     requires javafx.fxml;
 

--- a/src/main/java/osmosis/folder/inspector/FolderInspector.java
+++ b/src/main/java/osmosis/folder/inspector/FolderInspector.java
@@ -10,15 +10,21 @@ import osmosis.folder.inspector.constants.ResourcePaths;
 import osmosis.folder.inspector.dimensions.Dimensions;
 
 import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class FolderInspector extends Application {
+    private static final Logger LOGGER = Logger.getLogger(FolderInspector.class.getName());
+
     @Override
     public void start(Stage primaryStage) throws Exception {
+        LOGGER.log(Level.INFO, "Initializing primary stage");
         setDimensions(primaryStage);
         Parent root = FXMLLoader.load(Objects.requireNonNull(getClass().getResource(ResourcePaths.MAIN_FXML)));
         primaryStage.setTitle(Constant.FOLDER_INSPECTOR);
         primaryStage.setScene(new Scene(root));
         primaryStage.show();
+        LOGGER.log(Level.INFO, "Primary stage shown");
     }
 
     private void setDimensions(Stage primaryStage) {

--- a/src/main/java/osmosis/folder/inspector/Main.java
+++ b/src/main/java/osmosis/folder/inspector/Main.java
@@ -1,10 +1,32 @@
 package osmosis.folder.inspector;
 
+import java.io.InputStream;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+
 public class Main {
+    private static final Logger LOGGER = Logger.getLogger(Main.class.getName());
+    private static final String LOGGING_PROPERTIES = "/logging.properties";
+
     private Main() {
     }
 
     public static void main(String[] args) {
+        configureLogging();
+        LOGGER.log(Level.INFO, "Starting Folder Inspector");
         FolderInspector.main(args);
+    }
+
+    private static void configureLogging() {
+        try (InputStream stream = Main.class.getResourceAsStream(LOGGING_PROPERTIES)) {
+            if (stream == null) {
+                System.err.println("Logging configuration not found on classpath: " + LOGGING_PROPERTIES);
+                return;
+            }
+            LogManager.getLogManager().readConfiguration(stream);
+        } catch (Exception exception) {
+            System.err.println("Failed to load logging configuration: " + exception.getMessage());
+        }
     }
 }

--- a/src/main/java/osmosis/folder/inspector/calculation/DirectorySizeCalculationTask.java
+++ b/src/main/java/osmosis/folder/inspector/calculation/DirectorySizeCalculationTask.java
@@ -7,8 +7,11 @@ import osmosis.folder.inspector.container.FileContainer;
 import java.util.List;
 import java.util.concurrent.ForkJoinTask;
 import java.util.concurrent.RecursiveTask;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class DirectorySizeCalculationTask extends RecursiveTask<Long> {
+    private static final Logger LOGGER = Logger.getLogger(DirectorySizeCalculationTask.class.getName());
     private final DirectoryContainer directoryContainer;
 
     public DirectorySizeCalculationTask(DirectoryContainer directoryContainer) {
@@ -23,6 +26,8 @@ public class DirectorySizeCalculationTask extends RecursiveTask<Long> {
         long size = directoriesSizes + filesSizes;
         directoryContainer.setSize(size);
         directoryContainer.invokeListener();
+        LOGGER.log(Level.INFO, "Finished size calculation for {0} (size={1} bytes)",
+                new Object[]{directoryContainer.getPath(), size});
         return size;
     }
 

--- a/src/main/java/osmosis/folder/inspector/calculation/DirectorySizeCalculator.java
+++ b/src/main/java/osmosis/folder/inspector/calculation/DirectorySizeCalculator.java
@@ -3,8 +3,11 @@ package osmosis.folder.inspector.calculation;
 import osmosis.folder.inspector.container.DirectoryContainer;
 
 import java.util.concurrent.ForkJoinPool;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class DirectorySizeCalculator {
+    private static final Logger LOGGER = Logger.getLogger(DirectorySizeCalculator.class.getName());
     private static final ForkJoinPool FORK_JOIN_POOL = new ForkJoinPool();
     private static final DirectorySizeCalculator INSTANCE = new DirectorySizeCalculator();
 
@@ -12,6 +15,7 @@ public class DirectorySizeCalculator {
     }
 
     public void calculate(DirectoryContainer container) {
+        LOGGER.log(Level.INFO, "Started size calculation for {0}", container.getPath());
         FORK_JOIN_POOL.submit(new DirectorySizeCalculationTask(container));
     }
 

--- a/src/main/java/osmosis/folder/inspector/container/ContainerFactory.java
+++ b/src/main/java/osmosis/folder/inspector/container/ContainerFactory.java
@@ -2,13 +2,17 @@ package osmosis.folder.inspector.container;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class ContainerFactory {
+    private static final Logger LOGGER = Logger.getLogger(ContainerFactory.class.getName());
 
     private ContainerFactory() {
     }
 
     public static DirectoryContainer createDirectoryContainer(File file) {
+        LOGGER.log(Level.INFO, "Creating root directory container for {0}", file.getAbsolutePath());
         return new DirectoryContainer(file, null);
     }
 

--- a/src/main/java/osmosis/folder/inspector/container/ContainerManager.java
+++ b/src/main/java/osmosis/folder/inspector/container/ContainerManager.java
@@ -1,6 +1,10 @@
 package osmosis.folder.inspector.container;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 public class ContainerManager {
+    private static final Logger LOGGER = Logger.getLogger(ContainerManager.class.getName());
     private static final ContainerManager INSTANCE = new ContainerManager();
     private DirectoryContainer currentContainer;
 
@@ -12,10 +16,12 @@ public class ContainerManager {
     }
 
     public void setCurrentContainer(DirectoryContainer currentContainer) {
+        LOGGER.log(Level.INFO, "Current container set to {0}", currentContainer.getPath());
         this.currentContainer = currentContainer;
     }
 
     public void clearContainer() {
+        LOGGER.log(Level.INFO, "Cleared current container");
         this.currentContainer = null;
     }
 

--- a/src/main/java/osmosis/folder/inspector/controllers/Controller.java
+++ b/src/main/java/osmosis/folder/inspector/controllers/Controller.java
@@ -14,8 +14,12 @@ import osmosis.folder.inspector.container.ContainerManager;
 import osmosis.folder.inspector.controllers.data.ControllersData;
 
 import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public abstract class Controller implements Initializable {
+    private static final Logger LOGGER = Logger.getLogger(Controller.class.getName());
+
     protected static final ControllersData data = ControllersData.getInstance();
     protected static final ContainerManager containerManager = ContainerManager.getInstance();
 
@@ -31,7 +35,7 @@ public abstract class Controller implements Initializable {
         try {
             stage.setScene(new Scene(FXMLLoader.load(Objects.requireNonNull(getClass().getResource(ResourcePathProvider.getFxml(resourceName))))));
         } catch (Exception exception) {
-            exception.printStackTrace();
+            LOGGER.log(Level.SEVERE, "Failed to load scene for resource " + resourceName, exception);
             showErrorAlert(ErrorMessages.ERROR_OCCURRED + exception.getMessage());
         }
     }

--- a/src/main/java/osmosis/folder/inspector/controllers/FoldersController.java
+++ b/src/main/java/osmosis/folder/inspector/controllers/FoldersController.java
@@ -29,8 +29,12 @@ import osmosis.folder.inspector.panes.ContainerPane;
 
 import java.net.URL;
 import java.util.ResourceBundle;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class FoldersController extends Controller implements ChildContainerReadyListener {
+    private static final Logger LOGGER = Logger.getLogger(FoldersController.class.getName());
+
     public VBox foldersVBox;
     public Button backButton;
     public Button rootButton;
@@ -43,6 +47,7 @@ public class FoldersController extends Controller implements ChildContainerReady
 
     @Override
     public void initialize(URL location, ResourceBundle resources) {
+        LOGGER.log(Level.INFO, "Folders controller initialized");
         installTooltips();
         initializeAddressBar();
         initializeParentContainer();
@@ -64,6 +69,7 @@ public class FoldersController extends Controller implements ChildContainerReady
         ClipboardContent content = new ClipboardContent();
         content.putString(addressBar.getText());
         clipboard.setContent(content);
+        LOGGER.log(Level.INFO, "Copied address to clipboard: {0}", addressBar.getText());
     }
 
     @FXML
@@ -106,6 +112,7 @@ public class FoldersController extends Controller implements ChildContainerReady
     }
 
     private void goBackToMainMenu(ActionEvent actionEvent) {
+        LOGGER.log(Level.INFO, "Returning to main menu");
         setScene(actionEvent, ResourcePaths.MAIN_FXML);
         ContainerManager.getInstance().clearContainer();
     }

--- a/src/main/java/osmosis/folder/inspector/controllers/MainController.java
+++ b/src/main/java/osmosis/folder/inspector/controllers/MainController.java
@@ -15,8 +15,12 @@ import osmosis.folder.inspector.exceptions.InvalidDirectoryException;
 import java.io.File;
 import java.net.URL;
 import java.util.ResourceBundle;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class MainController extends Controller {
+    private static final Logger LOGGER = Logger.getLogger(MainController.class.getName());
+
     public VBox mainBox;
     public Button inspectButton;
     public TextField pathInputField;
@@ -24,6 +28,7 @@ public class MainController extends Controller {
 
     @Override
     public void initialize(URL location, ResourceBundle resources) {
+        LOGGER.log(Level.INFO, "Main controller initialized");
         Platform.runLater(this::initializePathInputField);
     }
 
@@ -45,9 +50,11 @@ public class MainController extends Controller {
         try {
             file = PathInputResolver.resolveDirectory(pathInputField.getText());
         } catch (InvalidDirectoryException exception) {
+            LOGGER.log(Level.WARNING, "Invalid directory provided: {0}", exception.getMessage());
             showAlert(exception.getMessage());
             return;
         }
+        LOGGER.log(Level.INFO, "Root directory selected: {0}", file.getAbsolutePath());
         goToFolderView(actionEvent, file);
     }
 

--- a/src/main/resources/logging.properties
+++ b/src/main/resources/logging.properties
@@ -1,0 +1,8 @@
+handlers=java.util.logging.ConsoleHandler
+
+.level=INFO
+
+java.util.logging.ConsoleHandler.level=INFO
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+
+java.util.logging.SimpleFormatter.format=%1$tF %1$tT %4$s %3$s - %5$s%6$s%n


### PR DESCRIPTION
Closes #16

## Summary
- Introduces a `java.util.logging` (JUL) based logging facade with no new dependencies
- Adds `src/main/resources/logging.properties` (ConsoleHandler at INFO, root at INFO, simple formatter) and wires it up in `Main` via `LogManager.getLogManager().readConfiguration(...)` before launching JavaFX (best-effort, falls back to stderr)
- Adds `Logger` instances and meaningful INFO/WARNING/SEVERE statements at app start, controller initialization, root directory selection, calculation start/end, container creation/management, and scene loading errors
- Replaces the lone `e.printStackTrace()` in `Controller` with a `LOGGER.log(Level.SEVERE, ...)` call carrying the throwable
- Adds `requires java.logging` to `module-info.java`

## Test plan
- [x] `mvn clean verify` succeeds (compile, checkstyle, all 6 unit tests pass)
- [x] Log output is visible during test runs and shows the configured `SimpleFormatter` layout
- [ ] Manually launch the JavaFX app and confirm logs appear on console for app start, directory selection, and size calculation lifecycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)