### PR TITLE
feat: add multi-OS release pipeline (#11)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,182 @@
+name: Release
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build installer (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            installer_type: deb
+            installer_glob: 'dist/*.deb'
+          - os: macos-latest
+            installer_type: dmg
+            installer_glob: 'dist/*.dmg'
+          - os: windows-latest
+            installer_type: msi
+            installer_glob: 'dist/*.msi'
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Resolve versions
+        id: ver
+        shell: bash
+        run: |
+          RAW="${GITHUB_REF_NAME#v}"
+          APP_VERSION="$(printf '%s' "$RAW" | sed -E 's/[-+].*$//')"
+          if ! printf '%s' "$APP_VERSION" | grep -Eq '^[0-9]+(\.[0-9]+){0,2}$'; then
+            echo "Derived app version '$APP_VERSION' is not a valid jpackage version (expected MAJOR[.MINOR[.PATCH]])." >&2
+            exit 1
+          fi
+          echo "raw=$RAW" >> "$GITHUB_OUTPUT"
+          echo "app_version=$APP_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Build shaded jar
+        shell: bash
+        run: mvn -B clean package
+
+      - name: Stage shaded jar for jpackage
+        shell: bash
+        run: |
+          rm -rf staging dist
+          mkdir -p staging dist
+          SHADED_JAR="$(ls target/folder-inspector-*.jar | grep -v '^target/original-' | head -n 1)"
+          if [ -z "$SHADED_JAR" ]; then
+            echo "Could not locate shaded jar in target/." >&2
+            ls -la target >&2
+            exit 1
+          fi
+          cp "$SHADED_JAR" staging/
+          echo "MAIN_JAR=$(basename "$SHADED_JAR")" >> "$GITHUB_ENV"
+
+      - name: Build installer with jpackage
+        shell: bash
+        run: |
+          set -euo pipefail
+          EXTRA_ARGS=()
+          case "${{ matrix.installer_type }}" in
+            msi)
+              EXTRA_ARGS+=(--win-dir-chooser --win-menu --win-shortcut)
+              ;;
+          esac
+          jpackage \
+            --type ${{ matrix.installer_type }} \
+            --name FolderInspector \
+            --app-version "${{ steps.ver.outputs.app_version }}" \
+            --vendor "osmosis" \
+            --input staging \
+            --main-jar "$MAIN_JAR" \
+            --main-class osmosis.folder.inspector.Main \
+            --dest dist \
+            "${EXTRA_ARGS[@]}"
+
+      - name: Rename installer to include full tag version
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          for f in ${{ matrix.installer_glob }}; do
+            ext="${f##*.}"
+            new="dist/FolderInspector-${{ steps.ver.outputs.raw }}.${ext}"
+            if [ "$f" != "$new" ]; then
+              mv "$f" "$new"
+            fi
+          done
+
+      - name: Upload installer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: installer-${{ matrix.os }}
+          path: ${{ matrix.installer_glob }}
+          if-no-files-found: error
+
+      - name: Upload shaded jar (ubuntu only)
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: shaded-jar
+          path: target/folder-inspector-*.jar
+          if-no-files-found: error
+
+      - name: Build sources archive (ubuntu only)
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          mkdir -p dist
+          git archive --format=zip HEAD -o "dist/folder-inspector-${{ steps.ver.outputs.raw }}-sources.zip"
+
+      - name: Upload sources archive (ubuntu only)
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: sources
+          path: dist/folder-inspector-*-sources.zip
+          if-no-files-found: error
+
+  release:
+    name: Publish GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Flatten artifacts
+        shell: bash
+        run: |
+          mkdir -p release
+          find artifacts -type f \( -name '*.deb' -o -name '*.dmg' -o -name '*.msi' -o -name '*.jar' -o -name '*.zip' \) -exec cp {} release/ \;
+          ls -la release
+
+      - name: Extract release notes from CHANGELOG
+        id: notes
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          NOTES_FILE="release_notes.md"
+          if [ -f CHANGELOG.md ]; then
+            awk -v ver="$VERSION" '
+              BEGIN { capture = 0 }
+              /^## \[/ {
+                if (capture) { exit }
+                if (index($0, "[" ver "]") > 0) { capture = 1; next }
+              }
+              /^\[[^]]+\]:/ { if (capture) { exit } }
+              capture { print }
+            ' CHANGELOG.md > "$NOTES_FILE"
+          fi
+          if [ ! -s "$NOTES_FILE" ]; then
+            printf 'Release %s.\n\nSee CHANGELOG.md for details.\n' "$VERSION" > "$NOTES_FILE"
+          fi
+          echo "path=$NOTES_FILE" >> "$GITHUB_OUTPUT"
+
+      - name: Create draft GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          name: ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          body_path: ${{ steps.notes.outputs.path }}
+          files: release/*
+          fail_on_unmatched_files: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Multi-OS release pipeline that publishes jpackage installers (`.dmg`, `.deb`, `.msi`),
+  the shaded JAR, and a sources archive to GitHub Releases on `v*` tag pushes.
+- `CHANGELOG.md` following the Keep a Changelog format.
+
+## [1.0.0] - 2026-05-09
+
+### Added
+
+- Initial public release of Folder Inspector, a JavaFX desktop tool for
+  inspecting folder contents and sizes.
+- Path validation rules for selected directories.
+- Toolbar icons for copy, file, folder, and link actions.
+- Unit tests for `Container`, `DirectorySizeCalculator`, and `DigitalFormatter`.
+- Continuous integration workflow that builds and tests pull requests on `main`.
+
+[Unreleased]: https://github.com/osama-salman99/folder-inspector/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/osama-salman99/folder-inspector/releases/tag/v1.0.0


### PR DESCRIPTION
Closes #11

## Summary

- Adds `CHANGELOG.md` (Keep a Changelog format) with an `Unreleased` section and an initial `1.0.0` placeholder.
- Adds `.github/workflows/release.yaml`, a tag-triggered (`v*`) pipeline that:
  - Builds the existing shaded jar (`mvn -B clean package`) on `macos-latest`, `ubuntu-latest`, and `windows-latest`.
  - Runs `jpackage` per OS to produce native installers: `.dmg` (macOS), `.deb` (Ubuntu), `.msi` (Windows, with `--win-dir-chooser --win-menu --win-shortcut`).
  - Produces a `git archive` sources zip on the Ubuntu runner only.
  - Uploads the shaded jar, sources zip, and all installers as artifacts.
  - Runs a follow-up `release` job that downloads everything and uses `softprops/action-gh-release@v2` to create a **draft** GitHub Release. The body is extracted from the matching `CHANGELOG.md` section via `awk`.
- Tag version handling: derives the raw version from `${{ github.ref_name }}` (strip leading `v`), then trims any pre-release / build-metadata suffix to satisfy `jpackage --app-version` (which only accepts `MAJOR[.MINOR[.PATCH]]`). The full raw version is still used in artifact filenames.

## Deferred / called-out follow-ups

- **Workflow has not been live-tested.** I cannot push a tag from here; please validate by pushing a `v0.0.1-test` tag first and confirming each runner produces an installer and the draft release renders correctly.
- **Application icon:** `jpackage` needs `.icns` (macOS), `.ico` (Windows), and a `.png` (Linux). The repo only has PNGs at `src/main/resources/osmosis/icons/`, so I omitted `--icon` to keep this PR focused. Adding per-OS icons is a small follow-up.
- **Maven version sync:** `pom.xml` is fixed at `1.0.0-SNAPSHOT`; the workflow does **not** rewrite it for the release. Installers are stamped via `--app-version`, but the embedded shaded-jar manifest still says `1.0.0-SNAPSHOT`. Switching the pom to use `${revision}` and passing `-Drevision=...` is a separate cleanup.
- **CHANGELOG hygiene:** the `1.0.0` entry is a brief reconstruction from `git log`. Future releases should add entries under `Unreleased` ahead of cutting a tag.

## Test plan

- [x] `mvn -B clean verify` passes locally on the worktree.
- [x] `release.yaml` parses cleanly with `yq`.
- [x] Local smoke test of `jpackage --type app-image` against the shaded jar succeeds on macOS.
- [x] Tag-version derivation handles `v1.0.0`, `v0.0.1-test`, `v1.0.0-rc.1`, `v2.3`, `v10`, `v1.2.3+build5`.
- [x] CHANGELOG extraction `awk` snippet returns only the `1.0.0` block.
- [ ] Push a `v0.0.1-test` tag and confirm all three matrix jobs succeed.
- [ ] Verify the resulting draft release contains: `.dmg`, `.deb`, `.msi`, the shaded `.jar`, and the sources `.zip`.
- [ ] Install each installer on its target OS and launch FolderInspector.
- [ ] After a successful dry-run, delete the test tag and draft release before publishing the real `v1.0.0`.

Generated with [Claude Code](https://claude.com/claude-code)