### PR TITLE
refactor: decouple controllers from container layer

### DIFF
--- a/src/main/java/osmosis/folder/inspector/calculation/DirectorySizeCalculationTask.java
+++ b/src/main/java/osmosis/folder/inspector/calculation/DirectorySizeCalculationTask.java
@@ -21,8 +21,7 @@ public class DirectorySizeCalculationTask extends RecursiveTask<Long> {
         long directoriesSizes = calculateDirectoriesSizes(childrenContainers);
         long filesSizes = calculateFilesSizes(childrenContainers);
         long size = directoriesSizes + filesSizes;
-        directoryContainer.setSize(size);
-        directoryContainer.invokeListener();
+        directoryContainer.completeWithSize(size);
         return size;
     }
 

--- a/src/main/java/osmosis/folder/inspector/container/ContainerManager.java
+++ b/src/main/java/osmosis/folder/inspector/container/ContainerManager.java
@@ -1,5 +1,8 @@
 package osmosis.folder.inspector.container;
 
+import java.io.File;
+import java.util.Objects;
+
 public class ContainerManager {
     private static final ContainerManager INSTANCE = new ContainerManager();
     private DirectoryContainer currentContainer;
@@ -11,8 +14,16 @@ public class ContainerManager {
         return currentContainer;
     }
 
-    public void setCurrentContainer(DirectoryContainer currentContainer) {
-        this.currentContainer = currentContainer;
+    public void setRootContainer(File file) {
+        this.currentContainer = ContainerFactory.createDirectoryContainer(file);
+    }
+
+    public void navigateTo(DirectoryContainer container, ChildContainerReadyListener listener) {
+        if (Objects.nonNull(currentContainer)) {
+            currentContainer.clearChildContainerReadyListener();
+        }
+        this.currentContainer = container;
+        container.setChildContainerReadyListener(listener);
     }
 
     public void clearContainer() {

--- a/src/main/java/osmosis/folder/inspector/container/DirectoryContainer.java
+++ b/src/main/java/osmosis/folder/inspector/container/DirectoryContainer.java
@@ -24,7 +24,12 @@ public class DirectoryContainer extends Container {
         this.childContainerReadyListener = null;
     }
 
-    public void invokeListener() {
+    public void completeWithSize(long size) {
+        setSize(size);
+        invokeListener();
+    }
+
+    private void invokeListener() {
         if (hasListener()) {
             childContainerReadyListener.onContainerReady();
         } else if (hasParentContainer() && parent.hasListener()) {
@@ -42,9 +47,5 @@ public class DirectoryContainer extends Container {
 
     public boolean isEmpty() {
         return childrenContainersWrapper.isEmpty();
-    }
-
-    public void setSize(long size) {
-        super.setSize(size);
     }
 }

--- a/src/main/java/osmosis/folder/inspector/controllers/Controller.java
+++ b/src/main/java/osmosis/folder/inspector/controllers/Controller.java
@@ -16,8 +16,8 @@ import osmosis.folder.inspector.controllers.data.ControllersData;
 import java.util.Objects;
 
 public abstract class Controller implements Initializable {
-    protected static final ControllersData data = ControllersData.getInstance();
-    protected static final ContainerManager containerManager = ContainerManager.getInstance();
+    protected final ControllersData data = ControllersData.getInstance();
+    protected final ContainerManager containerManager = ContainerManager.getInstance();
 
     protected void setScene(ActionEvent actionEvent, String resourceName) {
         setSceneAsync(getStage(actionEvent), resourceName);

--- a/src/main/java/osmosis/folder/inspector/controllers/FoldersController.java
+++ b/src/main/java/osmosis/folder/inspector/controllers/FoldersController.java
@@ -22,7 +22,6 @@ import osmosis.folder.inspector.constants.providers.AlertProvider;
 import osmosis.folder.inspector.container.ChildContainerReadyListener;
 import osmosis.folder.inspector.container.ChildrenContainersStatistics;
 import osmosis.folder.inspector.container.Container;
-import osmosis.folder.inspector.container.ContainerManager;
 import osmosis.folder.inspector.container.DirectoryContainer;
 import osmosis.folder.inspector.formatter.DigitalFormatter;
 import osmosis.folder.inspector.panes.ContainerPane;
@@ -68,8 +67,9 @@ public class FoldersController extends Controller implements ChildContainerReady
 
     @FXML
     public void goBack(ActionEvent actionEvent) {
-        if (containerManager.getCurrentContainer().hasParentContainer()) {
-            showContainer(containerManager.getCurrentContainer().getParent());
+        DirectoryContainer current = containerManager.getCurrentContainer();
+        if (current.hasParentContainer()) {
+            showContainer(current.getParent());
             return;
         }
         confirmGoingToMainMenu(actionEvent);
@@ -107,13 +107,11 @@ public class FoldersController extends Controller implements ChildContainerReady
 
     private void goBackToMainMenu(ActionEvent actionEvent) {
         setScene(actionEvent, ResourcePaths.MAIN_FXML);
-        ContainerManager.getInstance().clearContainer();
+        containerManager.clearContainer();
     }
 
     private void showContainer(DirectoryContainer container) {
-        containerManager.getCurrentContainer().clearChildContainerReadyListener();
-        containerManager.setCurrentContainer(container);
-        container.setChildContainerReadyListener(this);
+        containerManager.navigateTo(container, this);
         addressBar.requestFocus();
         addressBar.setText(container.getPath());
         folderIsEmptyText.setVisible(container.isEmpty());
@@ -121,14 +119,22 @@ public class FoldersController extends Controller implements ChildContainerReady
     }
 
     private void refreshContents() {
-        foldersVBox.getChildren().clear();
         DirectoryContainer container = containerManager.getCurrentContainer();
+        ChildrenContainersStatistics statistics = ChildrenContainersStatistics.calculate(container.getChildrenContainers());
+        renderChildren(statistics);
+        renderDirectorySize(container);
+        updateProgress(statistics.getNumberOfReadyContainers(), statistics.getNumberOfChildren());
+    }
+
+    private void renderChildren(ChildrenContainersStatistics statistics) {
+        foldersVBox.getChildren().clear();
+        statistics.getChildrenContainers().forEach(this::addContainerPane);
+    }
+
+    private void renderDirectorySize(DirectoryContainer container) {
         if (container.isReady()) {
             directorySizeText.setText(DigitalFormatter.formatSize(container.getSize()));
         }
-        ChildrenContainersStatistics statistics = ChildrenContainersStatistics.calculate(container.getChildrenContainers());
-        statistics.getChildrenContainers().forEach(this::addContainerPane);
-        updateProgress(statistics.getNumberOfReadyContainers(), statistics.getNumberOfChildren());
     }
 
     private void updateProgress(long completed, long all) {

--- a/src/main/java/osmosis/folder/inspector/controllers/MainController.java
+++ b/src/main/java/osmosis/folder/inspector/controllers/MainController.java
@@ -9,7 +9,6 @@ import javafx.scene.control.TextField;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.VBox;
 import osmosis.folder.inspector.constants.ResourcePaths;
-import osmosis.folder.inspector.container.ContainerFactory;
 import osmosis.folder.inspector.exceptions.InvalidDirectoryException;
 
 import java.io.File;
@@ -59,7 +58,7 @@ public class MainController extends Controller {
 
     private void goToFolderView(ActionEvent actionEvent, File file) {
         data.setMainPath(file.getAbsolutePath());
-        containerManager.setCurrentContainer(ContainerFactory.createDirectoryContainer(file));
+        containerManager.setRootContainer(file);
         mainBox.setDisable(false);
         hideProgressIndicator();
         setScene(actionEvent, ResourcePaths.FOLDERS_FXML);

--- a/src/test/java/osmosis/folder/inspector/container/ContainerManagerTest.java
+++ b/src/test/java/osmosis/folder/inspector/container/ContainerManagerTest.java
@@ -6,6 +6,7 @@ import osmosis.folder.inspector.test.TestUtils;
 
 import java.io.File;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
@@ -26,20 +27,30 @@ class ContainerManagerTest {
     }
 
     @Test
-    public void setCurrentContainerStoresContainer() {
+    public void setRootContainerStoresContainerForFile() {
         File file = TestUtils.getInstance().getFile("folder1");
-        DirectoryContainer container = ContainerFactory.createDirectoryContainer(file);
 
-        ContainerManager.getInstance().setCurrentContainer(container);
+        ContainerManager.getInstance().setRootContainer(file);
 
-        assertSame(container, ContainerManager.getInstance().getCurrentContainer());
+        DirectoryContainer current = ContainerManager.getInstance().getCurrentContainer();
+        assertEquals(file.getAbsolutePath(), current.getPath());
+    }
+
+    @Test
+    public void navigateToReplacesCurrentContainer() {
+        File rootFile = TestUtils.getInstance().getFile("folder1");
+        ContainerManager.getInstance().setRootContainer(rootFile);
+        DirectoryContainer child = ContainerFactory.createDirectoryContainer(
+                TestUtils.getInstance().getFile("folder1/folder2"));
+
+        ContainerManager.getInstance().navigateTo(child, () -> { });
+
+        assertSame(child, ContainerManager.getInstance().getCurrentContainer());
     }
 
     @Test
     public void clearContainerResetsToNull() {
-        File file = TestUtils.getInstance().getFile("folder1");
-        DirectoryContainer container = ContainerFactory.createDirectoryContainer(file);
-        ContainerManager.getInstance().setCurrentContainer(container);
+        ContainerManager.getInstance().setRootContainer(TestUtils.getInstance().getFile("folder1"));
 
         ContainerManager.getInstance().clearContainer();
 

--- a/src/test/java/osmosis/folder/inspector/container/DirectoryContainerTest.java
+++ b/src/test/java/osmosis/folder/inspector/container/DirectoryContainerTest.java
@@ -54,7 +54,7 @@ class DirectoryContainerTest {
         ChildContainerReadyListener listener = mock(ChildContainerReadyListener.class);
         container.setChildContainerReadyListener(listener);
 
-        container.invokeListener();
+        container.completeWithSize(0L);
 
         verify(listener, times(1)).onContainerReady();
     }
@@ -67,7 +67,7 @@ class DirectoryContainerTest {
         ChildContainerReadyListener parentListener = mock(ChildContainerReadyListener.class);
         parent.setChildContainerReadyListener(parentListener);
 
-        child.invokeListener();
+        child.completeWithSize(0L);
 
         verify(parentListener, times(1)).onContainerReady();
     }
@@ -78,7 +78,7 @@ class DirectoryContainerTest {
         DirectoryContainer parent = ContainerFactory.createDirectoryContainer(parentFile);
         DirectoryContainer child = new DirectoryContainer(TestUtils.getInstance().getFile("folder1/folder2"), parent);
 
-        child.invokeListener();
+        child.completeWithSize(0L);
     }
 
     @Test
@@ -86,7 +86,7 @@ class DirectoryContainerTest {
         File file = TestUtils.getInstance().getFile("folder1");
         DirectoryContainer container = ContainerFactory.createDirectoryContainer(file);
 
-        container.invokeListener();
+        container.completeWithSize(0L);
     }
 
     @Test
@@ -97,17 +97,17 @@ class DirectoryContainerTest {
         container.setChildContainerReadyListener(listener);
 
         container.clearChildContainerReadyListener();
-        container.invokeListener();
+        container.completeWithSize(0L);
 
         verify(listener, never()).onContainerReady();
     }
 
     @Test
-    public void setSizeUpdatesContainerSize() {
+    public void completeWithSizeUpdatesContainerSize() {
         File file = TestUtils.getInstance().getFile("folder1");
         DirectoryContainer container = ContainerFactory.createDirectoryContainer(file);
 
-        container.setSize(987L);
+        container.completeWithSize(987L);
 
         assertEquals(987L, container.getSize());
     }

--- a/src/test/java/osmosis/folder/inspector/controllers/FoldersControllerNestedTest.java
+++ b/src/test/java/osmosis/folder/inspector/controllers/FoldersControllerNestedTest.java
@@ -35,9 +35,7 @@ class FoldersControllerNestedTest {
 
     @Start
     private void start(Stage stage) throws Exception {
-        DirectoryContainer container = ContainerFactory.createDirectoryContainer(
-                TestUtils.getInstance().getFile("folder1"));
-        ContainerManager.getInstance().setCurrentContainer(container);
+        ContainerManager.getInstance().setRootContainer(TestUtils.getInstance().getFile("folder1"));
 
         Parent root = FXMLLoader.load(Objects.requireNonNull(
                 getClass().getResource("/osmosis/folder/inspector/" + ResourcePaths.FOLDERS_FXML)));
@@ -88,11 +86,11 @@ class FoldersControllerNestedTest {
 
     @Test
     public void goBackWithParentNavigatesUp(FxRobot robot) {
-        DirectoryContainer parent = ContainerFactory.createDirectoryContainer(
-                TestUtils.getInstance().getFile("folder1"));
+        ContainerManager.getInstance().setRootContainer(TestUtils.getInstance().getFile("folder1"));
+        DirectoryContainer parent = ContainerManager.getInstance().getCurrentContainer();
         DirectoryContainer child = new DirectoryContainer(
                 TestUtils.getInstance().getFile("folder1/folder2"), parent);
-        ContainerManager.getInstance().setCurrentContainer(child);
+        ContainerManager.getInstance().navigateTo(child, () -> { });
 
         Button back = robot.lookup("#backButton").queryAs(Button.class);
         robot.interact(back::fire);

--- a/src/test/java/osmosis/folder/inspector/controllers/FoldersControllerTest.java
+++ b/src/test/java/osmosis/folder/inspector/controllers/FoldersControllerTest.java
@@ -40,8 +40,7 @@ class FoldersControllerTest {
     @Start
     private void start(Stage stage) throws Exception {
         rootDir = TestUtils.getInstance().getFile("folder1/folder2");
-        DirectoryContainer container = ContainerFactory.createDirectoryContainer(rootDir);
-        ContainerManager.getInstance().setCurrentContainer(container);
+        ContainerManager.getInstance().setRootContainer(rootDir);
 
         Parent root = FXMLLoader.load(Objects.requireNonNull(
                 getClass().getResource("/osmosis/folder/inspector/" + ResourcePaths.FOLDERS_FXML)));
@@ -138,7 +137,7 @@ class FoldersControllerTest {
         WaitForAsyncUtils.waitForFxEvents();
 
         DirectoryContainer current = ContainerManager.getInstance().getCurrentContainer();
-        current.setSize(1234L);
+        current.completeWithSize(1234L);
         robot.interact(() -> {
             // simulate onContainerReady() which schedules refreshContents on the FX thread
         });


### PR DESCRIPTION
Closes #8

## Summary
- `ContainerManager.setRootContainer(File)` now owns directory-container creation, removing `ContainerFactory` and the raw `setCurrentContainer` call from `MainController`.
- `ContainerManager.navigateTo(container, listener)` encapsulates the clear-old-listener / set-current / register-new-listener dance, replacing three direct calls in `FoldersController.showContainer`.
- `FoldersController` no longer reaches at `ContainerManager.getInstance()` directly; the inherited `containerManager` field is used consistently.
- `DirectoryContainer.completeWithSize(long)` replaces the public `setSize` widening plus the public `invokeListener()`; the calculation task now expresses intent and the listener trigger is private to the container.
- `Controller.data` and `Controller.containerManager` are instance fields instead of `static`, so subclass controllers no longer share global mutable references through the parent class.
- `FoldersController.refreshContents` is split into `renderChildren` / `renderDirectorySize` / `updateProgress` to give each step a name and a single responsibility.

## Test plan
- [x] `mvn clean verify` passes (checkstyle clean, all tests green)
- [ ] Manual smoke: launch app, inspect a folder, drill into subfolders, hit Back, return to main menu, re-inspect