### PR TITLE
chore: raise JaCoCo line coverage minimum to 95% (#129)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <maven-compiler-plugin-version>3.14.1</maven-compiler-plugin-version>
         <maven-checkstyle-plugin-version>3.6.0</maven-checkstyle-plugin-version>
         <jacoco-maven-plugin-version>0.8.13</jacoco-maven-plugin-version>
-        <jacoco.line.coverage.minimum>0.90</jacoco.line.coverage.minimum>
+        <jacoco.line.coverage.minimum>0.95</jacoco.line.coverage.minimum>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Closes #129

## Summary
- Bumps `jacoco.line.coverage.minimum` from 0.90 to 0.95 in `pom.xml`.
- Current line coverage on the included bundle is 100% (per #128's report), so the new threshold passes without code changes.

## Test plan
- [x] `mvn clean verify` — BUILD SUCCESS, JaCoCo "All coverage checks have been met"
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)