### PR TITLE
chore: raise JaCoCo line coverage minimum to 100% (#131)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <maven-compiler-plugin-version>3.14.1</maven-compiler-plugin-version>
         <maven-checkstyle-plugin-version>3.6.0</maven-checkstyle-plugin-version>
         <jacoco-maven-plugin-version>0.8.13</jacoco-maven-plugin-version>
-        <jacoco.line.coverage.minimum>0.95</jacoco.line.coverage.minimum>
+        <jacoco.line.coverage.minimum>1.00</jacoco.line.coverage.minimum>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Closes #131

## Summary
- Bumps `jacoco.line.coverage.minimum` from 0.95 to 1.00 in `pom.xml`.
- Current line coverage on the included bundle is 100%, so the new floor passes.

## Test plan
- [x] `mvn clean verify` — BUILD SUCCESS, JaCoCo "All coverage checks have been met"
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)